### PR TITLE
fix responsive header UI on screen width ranged 760px - 991px #34

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -65,8 +65,66 @@ html {
     /* background: url("../img/hero-bg.png") no-repeat center; */
     background-size: cover;
     /* border-radius: 0 0 50% 50% / 4%; */
+    
   }
 }
+
+@media (min-width: 760px) and (max-width: 991px) {
+  #fh5co-hero-wrapper {
+    padding-top: 20vh;
+    padding-bottom: 5vh;
+    background-color: #F7FAFD;
+    background-size: cover;
+  }
+
+  .navbar-brand {
+    font-size: 24px; /* Adjust font size for the navbar brand */
+  }
+
+  .nav-link {
+    margin: 0 20px; /* Adjust margin for the navigation links */
+    font-size: 14px; /* Adjust font size for navigation links */
+  }
+
+  .social-icons-header i {
+    font-size: 18px; /* Adjust font size for social icons */
+  }
+
+  .fh5co-hero-inner > h1 {
+    font-size: 40px; /* Adjust font size for the hero heading */
+  }
+
+  .fh5co-hero-inner > p {
+    width: 300px; /* Adjust width for the hero paragraph */
+    font-size: 12px; /* Adjust font size for the hero paragraph */
+    margin-top: 20px; /* Adjust margin top for the hero paragraph */
+    margin-bottom: 20px; /* Adjust margin bottom for the hero paragraph */
+  }
+
+  .fh5co-hero-inner .download-btn-first {
+    font-size: 12px; /* Adjust font size for download button */
+    padding: 8px 12px; /* Adjust padding for download button */
+  }
+
+  .fh5co-hero-inner .features-btn-first {
+    font-size: 12px; /* Adjust font size for features button */
+    padding: 6px 10px; /* Adjust padding for features button */
+  }
+
+  #faqs{
+    /* height: 100vh; */
+    display: flex;
+    padding-top: 7vh;
+    padding-bottom: 7vh;
+    align-items: center; 
+  }
+  .faq-container-item-header {
+    font-size: 18px;
+}
+}
+
+
+
 
 .main-navbar-nav .navbar-brand {
   /* font-size: 38px; */
@@ -492,11 +550,11 @@ html {
     margin: 2rem auto;
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
+    /* justify-content: space-between; */
 }
 
 .faq-container-items {
-    width: 48%;
+    width: 47%;
     margin: 1rem 0.5rem;
     background-color: white;
     color: black;
@@ -513,6 +571,7 @@ html {
     align-items: center;
     position: relative;
     cursor: pointer;
+    /* font-size: 17px; */
 }
   
   .faq-container-item-header::after {
@@ -734,9 +793,9 @@ html {
 
   .fh5co-hero-inner .fh5co-hero-smartphone {
     position: absolute;
-right: -91px;
-top: 90px;
-height: 470px;
+    right: -91px;
+    top: 90px;
+    height: 470px;
   }
 
   .curved-bg-div {
@@ -939,7 +998,7 @@ height: 470px;
   }
 
   #fh5co-hero-wrapper {
-    height: 800px;
+    height: 900px;
   }
 
   .fh5co-advantages-outer .fh5co-advantages-grid-columns {
@@ -1076,6 +1135,7 @@ height: 470px;
 @media screen and (max-width: 520px) {
   #fh5co-hero-wrapper {
     height: 900px;
+    /* padding-top: 60vh; */
   }
 
   .fh5co-hero-inner > h1 {

--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@
 			<div class="row d-flex justify-content-between">
 				<div class="d-flex align-items-center order-1 order-lg-0">
 					<div>
-						<h2 class="text-lg-left fs-40 color-primary p-sm- mt-lg-3 mb-4 mb-lg-4  text-center animated fadeIn wow"
+						<h2 class="text-lg-left fs-40 color-primary p-sm- mt-lg-3 mb-4 mb-lg-4 text-bold text-center animated fadeIn wow"
 							data-wow-delay="0.47s">Frequently asked questions 
 						</h2>
 						<div class="col-12 p-0">


### PR DESCRIPTION
To trigger this view:

change the width of the browser's responsive viewing page to withing the range of 750px-990px OR

![image](https://github.com/phisoft/feecollec-web/assets/156404474/bfc2e971-5916-408a-8e22-6dd0fbc9ead8)
![image](https://github.com/phisoft/feecollec-web/assets/156404474/4699e633-bfda-4cc3-9cd1-bf03c732de34)



The iPad Air Mini dimensions (769x1024px) view:
![image](https://github.com/phisoft/feecollec-web/assets/156404474/9469025d-5ffb-4f13-800e-0484d64494f2)

![image](https://github.com/phisoft/feecollec-web/assets/156404474/015e0460-d606-416d-9d9f-1fa5c779aead)

